### PR TITLE
Log Scheduled Jobs

### DIFF
--- a/app/services/buy_it_now_bot_scheduler.rb
+++ b/app/services/buy_it_now_bot_scheduler.rb
@@ -107,4 +107,18 @@ class BuyItNowBotScheduler
       sleep 0.25
     end
   end
+
+  def log_job_in_google_sheet(auction:, run_at:)
+    datetime = DateTime.now.utc.strftime('%Y-%m-%d %H:%M:%S')
+    domain_name = auction.domain_name
+    bin_price = auction.bin_price
+
+    nested_array = [[datetime, domain_name, bin_price, run_at]]
+    spreadsheet_id = Rails.application.credentials.spreadsheet_id
+    range = 'scheduled_jobs!A1:D'
+    @gsa.append_values_from_nested_array(spreadsheet_id:, range:, nested_array:)
+    Rails.logger.info("Logged job for #{domain_name} in Google Sheets at #{auction_end_time}")
+  rescue StandardError => e
+    Rails.logger.error("Failed to log job in Google Sheets: #{e.message}")
+  end
 end

--- a/app/services/google_sheets_api.rb
+++ b/app/services/google_sheets_api.rb
@@ -125,6 +125,12 @@ class GoogleSheetsApi
     @service.append_spreadsheet_value(spreadsheet_id, range, values_range, value_input_option: 'USER_ENTERED')
   end
 
+  def append_values_from_nested_array(spreadsheet_id:, range:, nested_array:)
+    request_body = Google::Apis::SheetsV4::ValueRange.new
+    request_body.values = nested_array
+    @service.append_spreadsheet_value(spreadsheet_id, range, request_body, value_input_option: 'USER_ENTERED')
+  end
+
   def here_be_dragons(spreadsheet_id:, range:)
     csv_path = 'spec/fixtures/here_be_dragons.csv'
     clear_values(spreadsheet_id:, range:)


### PR DESCRIPTION
### ✅ **Key Changes**

#### 🗓 **Buy It Now Bot Enhancements**

* Added `log_job_in_google_sheet` method to `BuyItNowBotScheduler` to log scheduled auctions to Google Sheets.
* Added helper method `append_values_from_nested_array` in `GoogleSheetsApi` to support flexible sheet data logging.